### PR TITLE
Validations

### DIFF
--- a/marrow/widgets/base.py
+++ b/marrow/widgets/base.py
@@ -3,6 +3,7 @@
 from copy import copy
 
 from marrow.util.object import NoDefault
+import re
 from marrow.tags import html5 as tag
 
 from transforms import BaseTransform, BooleanTransform
@@ -158,6 +159,17 @@ class Input(Widget):
                 value = self.value,
                 **self.args
             )
+
+    def validate(self, data):
+        super(Input, self).validate(data)
+        value = data.get(self.name, None)
+        if self.args.get('required', False):
+            if not value or isinstance(value, str) and not value.strip():
+                raise ValidationError('{} field is required.'.format(self.name))
+        if self.args.get('pattern', False):
+            pattern = re.compile("(?u)^" + self.args.get('pattern') + "$")
+            if not pattern.match(value):
+                raise ValidationError('{} field is invalid.'.format(self.name))
 
 
 class BooleanInput(Input):

--- a/marrow/widgets/base.py
+++ b/marrow/widgets/base.py
@@ -11,6 +11,8 @@ from transforms import BaseTransform, BooleanTransform
 __all__ = ['Widget', 'NestedWidget', 'Form', 'FieldSet', 'Label', 'Layout', 'Input', 'BooleanInput', 'Link']
 
 
+class ValidationError(Exception): pass
+
 
 class Widget(object):
     transform = BaseTransform()
@@ -29,7 +31,13 @@ class Widget(object):
     def value(self):
         value = self.data.get(self.name, self.default)
         return self.transform(value) if self.transform else value
-    
+
+    def validate(self, data):
+        try:
+            self.native(data)
+        except Exception as e:
+            raise ValidationError(self.name, e)
+
     def native(self, data):
         value = data.get(self.name, None)
         

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+from __future__ import unicode_literals
+from marrow.widgets.base import ValidationError
+import unittest
+from marrow.widgets import Input
+
+
+class TestValidation(unittest.TestCase):
+    def setUp(self):
+        super(TestValidation, self).setUp()
+
+    def test_required_fail(self):
+        test_input = Input(type_='text', name_='test', required=True)
+        with self.assertRaisesRegexp(ValidationError, 'field is required.'):
+            test_input.validate({'test': ''})
+
+    def test_required_success(self):
+        test_input = Input(type_='text', name_='test', required=True)
+        try:
+            test_input.validate({'test': 'test data'})
+        except ValidationError as e:
+            self.fail(e)
+
+    def test_regex_fail(self):
+        test_input = Input(type_='text', name_='test', pattern=r'\w+')
+        with self.assertRaisesRegexp(ValidationError, 'field is invalid.'):
+            test_input.validate({'test': 'abcABC123!!!!!!!!'})
+
+    def test_regex_success(self):
+        test_input = Input(type_='text', name_='test', pattern=r'\w+')
+        try:
+            test_input.validate({'test': 'abcéèàùçœëüABC12ÉÈÀÙÇŒEËAÄ'})
+        except ValidationError as e:
+            self.fail(e)
+
+
+


### PR DESCRIPTION
Added validation basics to marrow.tags. You can now implement the validate method on widgets to add different rules. The Input widget comes with required and pattern support but it is easy to add your own requirements.
### Usage

Input widget example:

``` python
test_required_input = Input(type_='text', name_='test', required=True)
test_input = Input(type_='text', name_='test', pattern=r'\w+')
```

Own input widget example:

``` python

class MyInput(Input):
   def validate(self, data):
       super(Input, self).validate(data)  # Optional but does the required and pattern check
       value = data.get(self.name, None)
       if value != 'The value it needs to be':
           raise ValidationError('The value is not what it should be !')
```
